### PR TITLE
Fix for issue koppor/jabref#521 (add new features about drag&drop between bib libraries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,5 @@ For IntelliJ IDEA, just import the project via a Gradle Import by pointing at th
 JabRef development is powered by YourKit Java Profiler [![YourKit Java Profiler](https://www.yourkit.com/images/yk_logo.png)](https://www.yourkit.com/java/profiler/)
 
 [JabRef]: https://www.jabref.org
+
+ 


### PR DESCRIPTION
According to [issue#521 from koppor/jabref issue tracker](https://github.com/koppor/jabref/issues/521), we are adding new feature about allowing drag and drop of items between different opened bib libraries.
This PR will be submitted to [JabRef](https://github.com/JabRef/jabref) when it is ready.

### Behavior Description:

Now when dragging an entry of bib library, JabRef allows user to drop it on another opened library tab, and this item will be copied and added to the dropped library accordingly.

### Link issues that are fixed:
Fixed: https://github.com/JabRef/jabref/issues/521

### Screenshots for UI changes:

> Waiting for addition.

### Checklist / TODOs :

- [x] Code implement of this new feature
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
